### PR TITLE
Bug fix: setup output suggested using 'ssh -f' but meant 'ssh -F'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - When using `piggyback` for `scp`, the transfer will get two 100%, then apparently "hang" for several seconds. If you wait, it will finish correctly.
 
+## 1.0.2
+
+- During setup console output suggested using 'ssh -f configfile' vs. 'ssh -F configfile'.
+
 ## 1.0.1
 
 - Fixed an issue where tailing logs in an ssh session produced a want-read-error

--- a/piggyback.py
+++ b/piggyback.py
@@ -166,7 +166,7 @@ Host *
     Password:           <your proxy password>
 5: Click "Add"
 
-Run SSH: ssh -f {filename} <args>
+Run SSH: ssh -F {filename} <args>
     """)
 
 def eprint(*args, **kwargs):
@@ -200,4 +200,4 @@ def main():
 
 if __name__ == "__main__":
     main()
-    
+ 


### PR DESCRIPTION
```
     -F configfile
             Specifies an alternative per-user configuration file.  If a configuration file is
             given on the command line, the system-wide configuration file (/etc/ssh/ssh_config)
             will be ignored.  The default for the per-user configuration file is ~/.ssh/config.

     -f      Requests ssh to go to background just before command execution.  This is useful if ssh
             is going to ask for passwords or passphrases, but the user wants it in the background.
             This implies -n.  The recommended way to start X11 programs at a remote site is with
             something like ssh -f host xterm.
```